### PR TITLE
ADR-1687 Adding getSubscription API calls when user returns to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This is the backend microservice that handles Returns related operations for Alc
 - [Get User Answers](api-docs/getUserAnswers): `GET /alcohol-duty-returns/user-answers/:appaId/:periodKey`
 - [Get Return For Period](api-docs/getReturn.md): `GET /alcohol-duty-returns/producers/:appaId/returns/:periodKey`
 - [Get Obligation Details](api-docs/obligationDetails.md): `GET /alcohol-duty-returns/obligationDetails/:appaId`
+- [Get Open Obligation](api-docs/openObligation.md): `GET /alcohol-duty-returns/openObligation/:appaId/:periodKey`
+- [Get Valid Subscription Regimes](api-docs/subscriptionRegimes.md): `GET /alcohol-duty-returns/subscriptionSummary/:appaId`
+- [Clear User Answers](api-docs/clearUserAnswers.md): `DELETE /alcohol-duty-returns/user-answers/:appaId/:periodKey`
 - [Release Lock](api-docs/releaseLock.md): `DELETE /user-answers/lock/:appaId/:periodKey`
 - [Renew Lock (Keep Alive)](api-docs/renewLock.md): `PUT /user-answers/lock/:appaId/:periodKey/ttl`
 - [Set User Answers](api-docs/setUserAnswers): `PUT /alcohol-duty-returns/user-answers`

--- a/api-docs/clearUserAnswers.md
+++ b/api-docs/clearUserAnswers.md
@@ -1,0 +1,57 @@
+# Clear User Answers
+
+Deletes the UserAnswers structure from the repository if it exists, for the specified APPA ID and period key.
+
+Calls to this API must be made by an authenticated and authorised user with an ADR enrolment in order for the data to be
+returned.
+
+**URL**: `/user-answers/:appaId/:periodKey`
+
+**Method**: `DELETE`
+
+**URL Params**:
+
+| Parameter Name | Type   | Description    | Notes                       |
+|----------------|--------|----------------|-----------------------------|
+| appaId         | String | The appa Id    |                             |
+| periodKey      | String | The period key | YYAM (year, 'A,' month A-L) |
+
+**Required Request Headers**:
+
+| Header Name   | Header Value   | Description                                |
+|---------------|----------------|--------------------------------------------|
+| Authorization | Bearer {TOKEN} | A valid bearer token from the auth service |
+
+***Example request:***
+
+/alcohol-duty-returns/user-answers/AP0000000001/24AF
+
+## Responses
+
+### Success response
+
+**Code**: `200 OK`
+
+**Response Body**
+
+The response body returns a message indicating that the delete operation was successful. This will also occur if the
+user answers do not exist.
+
+**Response Body Examples**
+
+***An example message:***
+
+```
+User answers deleted for user Int-01234567-89ab-cdef-fdec-ba9876543210 on return AP0000000001/24AF
+```
+
+### Responses
+
+**Code**: `401 UNAUTHORIZED`
+This response can occur when a call is made by any consumer without an authorized session that has an ADR enrolment.
+
+**Code**: `423 LOCKED`
+The return is locked.
+
+**Code**: `500 INTERNAL_SERVER_ERROR`
+This response can occur if the query to the database fails.

--- a/api-docs/openObligation.md
+++ b/api-docs/openObligation.md
@@ -1,18 +1,19 @@
-# Get Obligation Details
+# Get Open Obligation
 
-Returns the Obligation Details (including those not Open).
+Returns the details of an Open Obligation for the specified APPA ID and period key.
 
 Calls to this API must be made by an authenticated and authorised user with an ADR enrolment in order for the data to be returned.
 
-**URL**: `/alcohol-duty-returns/obligationDetails/:appaId`
+**URL**: `/alcohol-duty-returns/openObligation/:appaId/:periodKey`
 
 **Method**: `GET`
 
 **URL Params**
 
-| Parameter Name | Type   | Description  | Notes      |
-|----------------|--------|--------------|------------|
-| appaId         | String |  The appa Id |            |
+| Parameter Name | Type   | Description    | Notes                       |
+|----------------|--------|----------------|-----------------------------|
+| appaId         | String | The appa Id    |                             |
+| periodKey      | String | The period key | YYAM (year, 'A,' month A-L) |
 
 **Required Request Headers**:
 
@@ -22,7 +23,7 @@ Calls to this API must be made by an authenticated and authorised user with an A
 
 ***Example request:***
 
-/alcohol-duty-returns/obligationDetails/AP0000000001
+/alcohol-duty-returns/obligationDetails/AP0000000001/25AA
 
 ## Responses
 
@@ -32,9 +33,10 @@ Calls to this API must be made by an authenticated and authorised user with an A
 
 **Response Body**
 
-The response body returns an array of obligations (each containing the following fields)
+The response body returns the open obligation (containing the following fields)
 
-If NOT_FOUND is returned by the upstream API, an empty array is returned.
+If there are no open obligations for the specified period, a NOT_FOUND error is returned by the upstream API.
+If any error occurs, the error status code (as a result) wraps the message and is passed downstream.
 
 | Field Name | Description                                        | Data Type | Mandatory/Optional | Notes                       |
 |------------|----------------------------------------------------|-----------|--------------------|-----------------------------|
@@ -46,31 +48,16 @@ If NOT_FOUND is returned by the upstream API, an empty array is returned.
 
 **Response Body Examples**
 
-***Two obligations returned, one open, one fulfilled:***
+***Open obligation returned:***
 
 ```json
-[
-  {
-    "status": "Open",
-    "fromDate": "2024-08-01",
-    "toDate": "2024-08-31",
-    "dueDate": "2024-09-10",
-    "periodKey": "24AH"
-  },
-  {
-    "status": "Fulfilled",
-    "fromDate": "2024-05-01",
-    "toDate": "2024-05-31",
-    "dueDate": "2024-06-15",
-    "periodKey": "24AE"
-  }
-]
-```
-
-***No obligation details found:***
-
-```json
-[]
+{
+  "status": "Open",
+  "fromDate": "2024-08-01",
+  "toDate": "2024-08-31",
+  "dueDate": "2024-09-10",
+  "periodKey": "24AH"
+}
 ```
 
 ### Responses
@@ -78,4 +65,7 @@ If NOT_FOUND is returned by the upstream API, an empty array is returned.
 This response can occur when a call is made by any consumer without an authorized session that has an ADR enrolment.
 
 **Code**: `404 NOT_FOUND`
-This response can occur if the upstream call to accounts does not return OK
+This response can occur if the APPA ID does not have an open obligation for the specified period.
+
+**Code**: `500 INTERNAL_SERVER_ERROR`
+This response can occur if there is an error getting obligations.

--- a/api-docs/subscriptionRegimes.md
+++ b/api-docs/subscriptionRegimes.md
@@ -1,0 +1,66 @@
+# Get Valid Subscription Regimes
+
+Returns the alcohol regimes under the subscription summary for the specified APPA ID.
+
+Calls to this API must be made by an authenticated and authorised user with an ADR enrolment in order for the data to be
+returned.
+
+**URL**: `/alcohol-duty-returns/subscriptionSummary/:appaId`
+
+**Method**: `GET`
+
+**URL Params**
+
+| Parameter Name | Type   | Description | Notes |
+|----------------|--------|-------------|-------|
+| appaId         | String | The appa Id |       |
+
+**Required Request Headers**:
+
+| Header Name   | Header Value   | Description                                |
+|---------------|----------------|--------------------------------------------|
+| Authorization | Bearer {TOKEN} | A valid bearer token from the auth service |
+
+***Example request:***
+
+/alcohol-duty-returns/subscriptionSummary/AP0000000001
+
+## Responses
+
+### Success response
+
+**Code**: `200 OK`
+
+**Response Body**
+
+The response body returns the set of alcohol regimes (possible values are: Beer, Cider, Wine, Spirits,
+OtherFermentedProduct). The set could be empty, but this should not happen in practice as all users should have at least
+one alcohol regime approval.
+
+If the subscription approval status is not Approved or Insolvent, a FORBIDDEN error is returned.
+If any error occurs, the error status code (as a result) wraps the message and is passed downstream.
+
+**Response Body Examples**
+
+***Set of alcohol regimes returned:***
+
+```json
+[
+  "Spirits",
+  "Wine",
+  "Cider",
+  "OtherFermentedProduct",
+  "Beer"
+]
+```
+
+### Responses
+
+**Code**: `401 UNAUTHORIZED`
+This response can occur when a call is made by any consumer without an authorized session that has an ADR enrolment.
+
+**Code**: `403 FORBIDDEN`
+This response can occur if the subscription approval status is not Approved or Insolvent.
+
+**Code**: `500 INTERNAL_SERVER_ERROR`
+This response can occur if there is an error getting subscriptions.

--- a/app/uk/gov/hmrc/alcoholdutyreturns/controllers/ObligationController.scala
+++ b/app/uk/gov/hmrc/alcoholdutyreturns/controllers/ObligationController.scala
@@ -51,10 +51,14 @@ class ObligationController @Inject() (
     (authorise andThen checkAppaId(appaId)).async { implicit request =>
       val returnId = ReturnId(appaId, periodKey)
       accountService.getOpenObligation(returnId).value.map {
-        case Left(errorResponse) =>
+        case Left(errorResponse)   =>
           logger
-            .warn(s"Unable to get an open obligation for ${returnId.appaId} ${returnId.periodKey} - ${errorResponse.statusCode} ${errorResponse.message}")
-          Status(errorResponse.statusCode)(s"Error: Unable to get an open obligation. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}")
+            .warn(
+              s"Unable to get an open obligation for ${returnId.appaId} ${returnId.periodKey} - ${errorResponse.statusCode} ${errorResponse.message}"
+            )
+          Status(errorResponse.statusCode)(
+            s"Error: Unable to get an open obligation. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
+          )
         case Right(obligationData) => Ok(Json.toJson(obligationData))
       }
     }

--- a/app/uk/gov/hmrc/alcoholdutyreturns/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/alcoholdutyreturns/controllers/SubscriptionController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-class SubscriptionController @Inject()(
+class SubscriptionController @Inject() (
   authorise: AuthorisedAction,
   checkAppaId: CheckAppaIdAction,
   accountService: AccountService,
@@ -38,11 +38,15 @@ class SubscriptionController @Inject()(
   def getValidSubscriptionRegimes(appaId: String): Action[AnyContent] =
     (authorise andThen checkAppaId(appaId)).async { implicit request =>
       accountService.getSubscriptionSummaryAndCheckStatus(appaId).value.map {
-        case Left(errorResponse) =>
+        case Left(errorResponse)        =>
           logger
-            .warn(s"Unable to get a valid subscription for $appaId - ${errorResponse.statusCode} ${errorResponse.message}")
-          Status(errorResponse.statusCode)(s"Error: Unable to get a valid subscription. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}")
-        case Right(subscriptionSummary)  => Ok(Json.toJson(subscriptionSummary.regimes))
+            .warn(
+              s"Unable to get a valid subscription for $appaId - ${errorResponse.statusCode} ${errorResponse.message}"
+            )
+          Status(errorResponse.statusCode)(
+            s"Error: Unable to get a valid subscription. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
+          )
+        case Right(subscriptionSummary) => Ok(Json.toJson(subscriptionSummary.regimes))
       }
     }
 }

--- a/app/uk/gov/hmrc/alcoholdutyreturns/testonly/controllers/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/alcoholdutyreturns/testonly/controllers/TestOnlyController.scala
@@ -16,16 +16,25 @@
 
 package uk.gov.hmrc.alcoholdutyreturns.testonly.controllers
 
+import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.alcoholdutyreturns.controllers.actions.{AuthorisedAction, CheckAppaIdAction}
+import uk.gov.hmrc.alcoholdutyreturns.models.AlcoholRegime._
+import uk.gov.hmrc.alcoholdutyreturns.models.ObligationStatus.{Fulfilled, Open}
+import uk.gov.hmrc.alcoholdutyreturns.models.{AlcoholRegime, ApprovalStatus, ObligationData, ReturnAndUserDetails, SubscriptionSummary, UserAnswers}
 import uk.gov.hmrc.alcoholdutyreturns.repositories.UserAnswersRepository
 import uk.gov.hmrc.alcoholdutyreturns.service.LockingService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import java.time.LocalDate
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 class TestOnlyController @Inject() (
   cc: ControllerComponents,
+  authorise: AuthorisedAction,
+  checkAppaId: CheckAppaIdAction,
   userAnswersRepository: UserAnswersRepository,
   lockingService: LockingService
 )(implicit ec: ExecutionContext)
@@ -37,4 +46,75 @@ class TestOnlyController @Inject() (
       _ <- lockingService.releaseAllLocks()
     } yield Ok("All data cleared")
   }
+
+  def createUserAnswers(regimes: String): Action[JsValue] =
+    authorise(parse.json).async { implicit request =>
+      withJsonBody[ReturnAndUserDetails] { returnAndUserDetails =>
+        val returnId = returnAndUserDetails.returnId
+        val appaId   = returnId.appaId
+
+        Try(getRegimeFlags(regimes)) match {
+          case Success((noOFP, noSpirits, noWine, noCiderNorPerry, noBeer)) =>
+            checkAppaId(appaId).invokeBlock[JsValue](
+              request,
+              { implicit request =>
+                lockingService
+                  .withLock(returnId, request.userId) {
+                    val alcoholRegimes      = flagsToApprovalTypes(noOFP, noSpirits, noWine, noCiderNorPerry, noBeer)
+                    val subscriptionSummary = SubscriptionSummary(ApprovalStatus.Approved, alcoholRegimes)
+                    val obligationData      = getObligationData(returnId.periodKey, LocalDate.now())
+                    val userAnswers         =
+                      UserAnswers.createUserAnswers(returnAndUserDetails, subscriptionSummary, obligationData)
+                    userAnswersRepository.add(userAnswers).map { userAnswers =>
+                      Created(Json.toJson(userAnswers))
+                    }
+                  }
+                  .map {
+                    case Some(result) => result
+                    case None         => Locked
+                  }
+              }
+            )
+          case Failure(e)                                                   => Future.successful(BadRequest(e.getMessage))
+        }
+      }
+    }
+
+  private def getObligationData(periodKey: String, now: LocalDate): ObligationData = ObligationData(
+    status = Open,
+    fromDate = now,
+    toDate = now.plusDays(1),
+    dueDate = now.plusDays(2),
+    periodKey = periodKey
+  )
+
+  private def getRegimeFlags(flagDigits: String) =
+    if (!flagDigits.matches("^\\d{2}$")) {
+      throw new RuntimeException("Invalid flag digits to specify regimes")
+    } else {
+      val flags = flagDigits.toInt
+
+      val noOFP           = (flags & 0x40) != 0
+      val noSpirits       = (flags & 0x08) != 0
+      val noWine          = (flags & 0x04) != 0
+      val noCiderNorPerry = (flags & 0x02) != 0
+      val noBeer          = (flags & 0x01) != 0
+
+      (noOFP, noSpirits, noWine, noCiderNorPerry, noBeer)
+    }
+
+  private def flagsToApprovalTypes(
+    noOFP: Boolean,
+    noSpirits: Boolean,
+    noWine: Boolean,
+    noCiderNorPerry: Boolean,
+    noBeer: Boolean
+  ): Set[AlcoholRegime] =
+    Set(
+      Some(Beer).filterNot(_ => noBeer),
+      Some(Cider).filterNot(_ => noCiderNorPerry),
+      Some(Wine).filterNot(_ => noWine),
+      Some(Spirits).filterNot(_ => noSpirits),
+      Some(OtherFermentedProduct).filterNot(_ => noOFP)
+    ).flatten
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,6 +8,9 @@ DELETE      /user-answers/lock/:appaId/:periodKey             uk.gov.hmrc.alcoho
 PUT         /user-answers/lock/:appaId/:periodKey/ttl         uk.gov.hmrc.alcoholdutyreturns.controllers.UserAnswersController.keepAlive(appaId, periodKey)
 
 GET         /obligationDetails/:appaId                        uk.gov.hmrc.alcoholdutyreturns.controllers.ObligationController.getObligationDetails(appaId)
+GET         /openObligation/:appaId/:periodKey                uk.gov.hmrc.alcoholdutyreturns.controllers.ObligationController.getOpenObligation(appaId:String, periodKey:String)
+
+GET         /subscriptionSummary/:appaId                      uk.gov.hmrc.alcoholdutyreturns.controllers.SubscriptionController.getValidSubscriptionRegimes(appaId: String)
 
 GET         /producers/:appaId/returns/:periodKey             uk.gov.hmrc.alcoholdutyreturns.controllers.ReturnsController.getReturn(appaId:String, periodKey:String)
 POST        /producers/:appaId/returns/:periodKey             uk.gov.hmrc.alcoholdutyreturns.controllers.ReturnsController.submitReturn(appaId:String, periodKey:String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,6 +4,7 @@
 GET         /user-answers/:appaId/:periodKey                  uk.gov.hmrc.alcoholdutyreturns.controllers.UserAnswersController.get(appaId:String, periodKey:String)
 PUT         /user-answers                                     uk.gov.hmrc.alcoholdutyreturns.controllers.UserAnswersController.set()
 POST        /user-answers                                     uk.gov.hmrc.alcoholdutyreturns.controllers.UserAnswersController.createUserAnswers()
+DELETE      /user-answers/:appaId/:periodKey                  uk.gov.hmrc.alcoholdutyreturns.controllers.UserAnswersController.delete(appaId:String, periodKey:String)
 DELETE      /user-answers/lock/:appaId/:periodKey             uk.gov.hmrc.alcoholdutyreturns.controllers.UserAnswersController.releaseReturnLock(appaId, periodKey)
 PUT         /user-answers/lock/:appaId/:periodKey/ttl         uk.gov.hmrc.alcoholdutyreturns.controllers.UserAnswersController.keepAlive(appaId, periodKey)
 

--- a/conf/test.routes
+++ b/conf/test.routes
@@ -1,2 +1,2 @@
-DELETE        /user-answers/clear-all        uk.gov.hmrc.alcoholdutyreturns.testonly.controllers.TestOnlyController.clearAllData()
-POST          /user-answers/:regimes         uk.gov.hmrc.alcoholdutyreturns.controllers.TestOnlyController.createUserAnswers(regimes: String)
+DELETE        /user-answers/clear-all                               uk.gov.hmrc.alcoholdutyreturns.testonly.controllers.TestOnlyController.clearAllData()
+POST          /user-answers/:beer/:cider/:wine/:spirits/:OFP        uk.gov.hmrc.alcoholdutyreturns.testonly.controllers.TestOnlyController.createUserAnswers(beer: Boolean, cider: Boolean, wine: Boolean, spirits: Boolean, OFP: Boolean)

--- a/conf/test.routes
+++ b/conf/test.routes
@@ -1,1 +1,2 @@
-DELETE        /user-answers/clear-all          uk.gov.hmrc.alcoholdutyreturns.testonly.controllers.TestOnlyController.clearAllData()
+DELETE        /user-answers/clear-all        uk.gov.hmrc.alcoholdutyreturns.testonly.controllers.TestOnlyController.clearAllData()
+POST          /user-answers/:regimes         uk.gov.hmrc.alcoholdutyreturns.controllers.TestOnlyController.createUserAnswers(regimes: String)

--- a/test/uk/gov/hmrc/alcoholdutyreturns/controllers/ObligationControllerSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyreturns/controllers/ObligationControllerSpec.scala
@@ -79,8 +79,10 @@ class ObligationControllerSpec extends SpecBase {
         val result: Future[Result] =
           controller.getOpenObligation(appaId, periodKey)(fakeRequest)
 
-        status(result)        mustBe errorResponse.statusCode
-        contentAsString(result) mustBe s"Error: Unable to get an open obligation. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
+        status(result) mustBe errorResponse.statusCode
+        contentAsString(
+          result
+        )              mustBe s"Error: Unable to get an open obligation. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
       }
     }
   }

--- a/test/uk/gov/hmrc/alcoholdutyreturns/controllers/ObligationControllerSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyreturns/controllers/ObligationControllerSpec.scala
@@ -30,7 +30,7 @@ import java.time.LocalDate
 import scala.concurrent.Future
 
 class ObligationControllerSpec extends SpecBase {
-  "ObligationController must" - {
+  "getObligationDetails must" - {
     "return 200 OK with obligations if successful" in new SetUp {
       when(mockAccountService.getObligations(eqTo(appaId))(any(), any()))
         .thenReturn(EitherT.rightT[Future, ErrorResponse](Seq(obligationData)))
@@ -51,6 +51,37 @@ class ObligationControllerSpec extends SpecBase {
 
       status(result)          mustBe NOT_FOUND
       contentAsString(result) mustBe "Error: {500,Unexpected Response}"
+    }
+  }
+
+  "getOpenObligation must" - {
+    "return 200 OK with obligation data if successful" in new SetUp {
+      when(mockAccountService.getOpenObligation(eqTo(returnId))(any(), any()))
+        .thenReturn(EitherT.rightT(obligationData))
+
+      val result: Future[Result] =
+        controller.getOpenObligation(appaId, periodKey)(fakeRequest)
+
+      status(result)        mustBe OK
+      contentAsJson(result) mustBe Json.toJson(obligationData)
+    }
+
+    Seq(
+      ("EntityNotFound", ErrorCodes.entityNotFound),
+      ("InvalidJson", ErrorCodes.invalidJson),
+      ("UnexpectedResponse", ErrorCodes.unexpectedResponse),
+      ("ObligationFulfilled", ErrorCodes.obligationFulfilled)
+    ).foreach { case (errorName, errorResponse) =>
+      s"return the status ${errorResponse.statusCode} if the account service returns the error $errorName when getting the open obligation" in new SetUp {
+        when(mockAccountService.getOpenObligation(eqTo(returnId))(any(), any()))
+          .thenReturn(EitherT.leftT(errorResponse))
+
+        val result: Future[Result] =
+          controller.getOpenObligation(appaId, periodKey)(fakeRequest)
+
+        status(result)        mustBe errorResponse.statusCode
+        contentAsString(result) mustBe s"Error: Unable to get an open obligation. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
+      }
     }
   }
 

--- a/test/uk/gov/hmrc/alcoholdutyreturns/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyreturns/controllers/SubscriptionControllerSpec.scala
@@ -55,8 +55,10 @@ class SubscriptionControllerSpec extends SpecBase {
         val result: Future[Result] =
           controller.getValidSubscriptionRegimes(appaId)(fakeRequest)
 
-        status(result)        mustBe errorResponse.statusCode
-        contentAsString(result) mustBe s"Error: Unable to get a valid subscription. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
+        status(result) mustBe errorResponse.statusCode
+        contentAsString(
+          result
+        )              mustBe s"Error: Unable to get a valid subscription. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
       }
     }
   }
@@ -64,6 +66,6 @@ class SubscriptionControllerSpec extends SpecBase {
   class SetUp {
     val mockAccountService: AccountService = mock[AccountService]
 
-    val controller     = new SubscriptionController(fakeAuthorisedAction, fakeCheckAppaIdAction, mockAccountService, cc)
+    val controller = new SubscriptionController(fakeAuthorisedAction, fakeCheckAppaIdAction, mockAccountService, cc)
   }
 }

--- a/test/uk/gov/hmrc/alcoholdutyreturns/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyreturns/controllers/SubscriptionControllerSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alcoholdutyreturns.controllers
+
+import cats.data.EitherT
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchersSugar.eqTo
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import uk.gov.hmrc.alcoholdutyreturns.base.SpecBase
+import uk.gov.hmrc.alcoholdutyreturns.models.{ApprovalStatus, ErrorCodes, ObligationData}
+import uk.gov.hmrc.alcoholdutyreturns.service.AccountService
+import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
+
+import java.time.LocalDate
+import scala.concurrent.Future
+
+class SubscriptionControllerSpec extends SpecBase {
+  "getValidSubscriptionRegimes must" - {
+    "return 200 OK with subscription regimes if successful" in new SetUp {
+      when(mockAccountService.getSubscriptionSummaryAndCheckStatus(eqTo(appaId))(any(), any()))
+        .thenReturn(EitherT.rightT(subscriptionSummary))
+
+      val result: Future[Result] =
+        controller.getValidSubscriptionRegimes(appaId)(fakeRequest)
+
+      status(result)        mustBe OK
+      contentAsJson(result) mustBe Json.toJson(subscriptionSummary.regimes)
+    }
+
+    Seq(
+      ("EntityNotFound", ErrorCodes.entityNotFound),
+      ("InvalidJson", ErrorCodes.invalidJson),
+      ("UnexpectedResponse", ErrorCodes.unexpectedResponse),
+      ("InvalidSubscriptionStatus(Revoked)", ErrorCodes.invalidSubscriptionStatus(ApprovalStatus.Revoked))
+    ).foreach { case (errorName, errorResponse) =>
+      s"return status ${errorResponse.statusCode} if the account service returns the error $errorName when getting the subscription summary" in new SetUp {
+        when(mockAccountService.getSubscriptionSummaryAndCheckStatus(eqTo(appaId))(any(), any()))
+          .thenReturn(EitherT.leftT(errorResponse))
+
+        val result: Future[Result] =
+          controller.getValidSubscriptionRegimes(appaId)(fakeRequest)
+
+        status(result)        mustBe errorResponse.statusCode
+        contentAsString(result) mustBe s"Error: Unable to get a valid subscription. Status: ${errorResponse.statusCode}, Message: ${errorResponse.message}"
+      }
+    }
+  }
+
+  class SetUp {
+    val mockAccountService: AccountService = mock[AccountService]
+
+    val controller     = new SubscriptionController(fakeAuthorisedAction, fakeCheckAppaIdAction, mockAccountService, cc)
+  }
+}

--- a/test/uk/gov/hmrc/alcoholdutyreturns/controllers/UserAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyreturns/controllers/UserAnswersControllerSpec.scala
@@ -226,6 +226,40 @@ class UserAnswersControllerSpec extends SpecBase {
     }
   }
 
+  "delete must" - {
+    "clear user answers and return 200 OK" in {
+      when(mockUserAnswersRepository.clearUserAnswersById(ArgumentMatchers.eq(returnId)))
+        .thenReturn(Future.successful(()))
+
+      val result: Future[Result] =
+        controller.delete(appaId, periodKey)(fakeRequest)
+
+      status(result) mustBe OK
+    }
+
+    "return 423 Locked when user answers is locked by another user" in {
+      val mockLockingService = mock[LockingService]
+      when(mockLockingService.withLock(any(), any())(any())).thenReturn(Future.successful(None))
+
+      val controller = new UserAnswersController(
+        fakeAuthorisedAction,
+        fakeCheckAppaIdAction,
+        mockUserAnswersRepository,
+        mockLockingService,
+        mockAccountService,
+        cc
+      )
+
+      when(mockUserAnswersRepository.clearUserAnswersById(ArgumentMatchers.eq(returnId)))
+        .thenReturn(Future.successful(()))
+
+      val result: Future[Result] =
+        controller.delete(appaId, periodKey)(fakeRequest)
+
+      status(result) mustBe LOCKED
+    }
+  }
+
   "releaseReturnLock must" - {
     "release the lock for a return and return 200 OK" in {
       val mockLockingService = mock[LockingService]


### PR DESCRIPTION
Created new controller methods to get open obligation and get subscription regimes for checking on "Before you start your return" when the user has existing user answers.
Created a controller method to delete user answers, which is called when the subscription regimes in existing user answers do not match those fetched.
Created a test only method to create existing user answers with the specified alcohol regimes.