### PR TITLE
ADR-2042 | Add enhanced logging for 422 on GET Return API call

### DIFF
--- a/app/uk/gov/hmrc/alcoholdutyreturns/connector/ReturnsConnector.scala
+++ b/app/uk/gov/hmrc/alcoholdutyreturns/connector/ReturnsConnector.scala
@@ -95,12 +95,14 @@ class ReturnsConnector @Inject() (
               Future.successful(Left(ErrorResponse(NOT_FOUND, ErrorCodes.entityNotFound.message)))
             case UNPROCESSABLE_ENTITY =>
               logger
-                .warn(s"Return request unprocessable for (appaId ${returnId.appaId}, periodKey ${returnId.periodKey})")
-              Future.successful(Left(ErrorResponse(UNPROCESSABLE_ENTITY, ErrorCodes.unprocessableEntity.message)))
+                .warn(
+                  s"Get return unprocessable for (appaId ${returnId.appaId}, periodKey ${returnId.periodKey}): ${response.body}"
+                )
+              Future.successful(Left(ErrorCodes.unexpectedResponse))
             case _                    =>
               val error: String = response.json.as[HttpErrorResponse].message
               logger.warn(
-                s"An exception was returned while trying to fetch return for (appaId ${returnId.appaId}, periodKey ${returnId.periodKey}): $error"
+                s"An exception was returned while trying to get return for (appaId ${returnId.appaId}, periodKey ${returnId.periodKey}): $error"
               )
               Future.failed(new InternalServerException(response.body))
           }

--- a/app/uk/gov/hmrc/alcoholdutyreturns/models/ErrorCodes.scala
+++ b/app/uk/gov/hmrc/alcoholdutyreturns/models/ErrorCodes.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.alcoholdutyreturns.models
 
-import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, GONE, INTERNAL_SERVER_ERROR, NOT_FOUND, SERVICE_UNAVAILABLE, UNAUTHORIZED, UNPROCESSABLE_ENTITY}
+import play.api.http.Status._
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.play.bootstrap.backend.http.ErrorResponse
 
@@ -29,9 +29,7 @@ object ErrorCodes {
   def invalidSubscriptionStatus(approvalStatus: ApprovalStatus): ErrorResponse =
     ErrorResponse(FORBIDDEN, s"Invalid subscription status: $approvalStatus")
   val unauthorisedRequest: ErrorResponse                                       = ErrorResponse(UNAUTHORIZED, "Unauthorised request")
-  val serviceUnavailable: ErrorResponse                                        = ErrorResponse(SERVICE_UNAVAILABLE, "Service unavailable")
   val unexpectedResponse: ErrorResponse                                        = ErrorResponse(INTERNAL_SERVER_ERROR, "Unexpected Response")
-  val unprocessableEntity: ErrorResponse                                       = ErrorResponse(UNPROCESSABLE_ENTITY, "Unprocessable entity")
 }
 
 case class HttpErrorResponse(

--- a/it/test/uk/gov/hmrc/alcoholdutyreturns/connector/ReturnsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/alcoholdutyreturns/connector/ReturnsConnectorSpec.scala
@@ -59,15 +59,15 @@ class ReturnsConnectorSpec extends ISpecBase {
         }
       }
 
-      "return a Unprocessable error if the call returns a 422 response without retry" in new SetUp {
+      "return an UnexpectedResponse error if the call returns a 422 response without retry" in new SetUp {
         stubGet(getReturnUrl, UNPROCESSABLE_ENTITY, "")
         whenReady(connectorWithRetry.getReturn(returnId), timeout = Timeout(Span(3, Seconds))) { result =>
-          result mustBe Left(ErrorCodes.unprocessableEntity)
+          result mustBe Left(ErrorCodes.unexpectedResponse)
           verifyGetWithoutRetry(getReturnUrl)
         }
       }
 
-      "return a UnexpectedResponse error if the call return a 500 response with retry" in new SetUp {
+      "return an UnexpectedResponse error if the call return a 500 response with retry" in new SetUp {
         stubGet(getReturnUrl, INTERNAL_SERVER_ERROR, Json.toJson(internalServerError).toString())
         whenReady(connectorWithRetry.getReturn(returnId)) { result =>
           result mustBe Left(ErrorCodes.unexpectedResponse)

--- a/test/uk/gov/hmrc/alcoholdutyreturns/controllers/ReturnsControllerSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyreturns/controllers/ReturnsControllerSpec.scala
@@ -67,12 +67,12 @@ class ReturnsControllerSpec extends SpecBase {
 
       "return 422 UNPROCESSABLE_ENTITY when not found" in new SetUp {
         when(mockReturnsConnector.getReturn(eqTo(returnId.copy(periodKey = periodKey)))(any()))
-          .thenReturn(Future.successful(Left(ErrorCodes.unprocessableEntity)))
+          .thenReturn(Future.successful(Left(ErrorCodes.unexpectedResponse)))
 
         val result: Future[Result] =
           controller.getReturn(appaId, periodKey)(fakeRequest)
 
-        status(result) mustBe UNPROCESSABLE_ENTITY
+        status(result) mustBe INTERNAL_SERVER_ERROR
       }
 
       "return 500 INTERNAL_SERVER_ERROR when an unexpected response" in new SetUp {


### PR DESCRIPTION
This PR will also pass a 422 from Get return back to the front end as a 500 such that we can be alerted. 